### PR TITLE
Return structs, not interfaces

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -33,7 +33,7 @@ func (f *BasePathFile) Name() string {
 	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
 }
 
-func NewBasePathFs(source Fs, path string) Fs {
+func NewBasePathFs(source Fs, path string) *BasePathFs {
 	return &BasePathFs{source: source, path: path}
 }
 

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -51,7 +51,7 @@ func TestRealPath(t *testing.T) {
 	}
 	defer fs.RemoveAll(anotherDir)
 
-	bp := NewBasePathFs(fs, baseDir).(*BasePathFs)
+	bp := NewBasePathFs(fs, baseDir)
 
 	subDir := filepath.Join(baseDir, "s1")
 

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -25,7 +25,7 @@ type CacheOnReadFs struct {
 	cacheTime time.Duration
 }
 
-func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) Fs {
+func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) *CacheOnReadFs {
 	return &CacheOnReadFs{base: base, layer: layer, cacheTime: cacheTime}
 }
 

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -22,7 +22,7 @@ type CopyOnWriteFs struct {
 	layer Fs
 }
 
-func NewCopyOnWriteFs(base Fs, layer Fs) Fs {
+func NewCopyOnWriteFs(base Fs, layer Fs) *CopyOnWriteFs {
 	return &CopyOnWriteFs{base: base, layer: layer}
 }
 

--- a/memmap.go
+++ b/memmap.go
@@ -31,7 +31,7 @@ type MemMapFs struct {
 	init sync.Once
 }
 
-func NewMemMapFs() Fs {
+func NewMemMapFs() *MemMapFs {
 	return &MemMapFs{}
 }
 

--- a/os.go
+++ b/os.go
@@ -27,7 +27,7 @@ var _ Lstater = (*OsFs)(nil)
 // (http://golang.org/pkg/os/).
 type OsFs struct{}
 
-func NewOsFs() Fs {
+func NewOsFs() *OsFs {
 	return &OsFs{}
 }
 

--- a/readonlyfs.go
+++ b/readonlyfs.go
@@ -12,7 +12,7 @@ type ReadOnlyFs struct {
 	source Fs
 }
 
-func NewReadOnlyFs(source Fs) Fs {
+func NewReadOnlyFs(source Fs) *ReadOnlyFs {
 	return &ReadOnlyFs{source: source}
 }
 

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -16,7 +16,7 @@ type RegexpFs struct {
 	source Fs
 }
 
-func NewRegexpFs(source Fs, re *regexp.Regexp) Fs {
+func NewRegexpFs(source Fs, re *regexp.Regexp) *RegexpFs {
 	return &RegexpFs{source: source, re: re}
 }
 


### PR DESCRIPTION
Idiomatic Go code should return structs that implement interfaces, not the interfaces themselves. This change does not break the API as all returned structs implicitly also implement the `Fs` interface.