### PR TITLE
Add initial symlink support

### DIFF
--- a/afero.go
+++ b/afero.go
@@ -105,4 +105,5 @@ var (
 	ErrFileNotFound      = os.ErrNotExist
 	ErrFileExists        = os.ErrExist
 	ErrDestinationExists = os.ErrExist
+	ErrNotImplemented    = errors.New("not implemented")
 )

--- a/afero.go
+++ b/afero.go
@@ -88,6 +88,9 @@ type Fs interface {
 	// happens.
 	Stat(name string) (os.FileInfo, error)
 
+	// Symlink creates newname as a symbolic link to oldname. If there is an error, it will be of type *LinkError.
+	Symlink(oldname, newname string) error
+
 	// The name of this FileSystem
 	Name() string
 

--- a/basepath.go
+++ b/basepath.go
@@ -177,4 +177,8 @@ func (b *BasePathFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 	return fi, false, err
 }
 
+func (b *BasePathFs) Symlink(oldname, newname string) error {
+	return ErrNotImplemented // FIXME implement
+}
+
 // vim: ts=4 sw=4 noexpandtab nolist syn=go

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -288,3 +288,7 @@ func (u *CacheOnReadFs) Create(name string) (File, error) {
 	}
 	return &UnionFile{Base: bfh, Layer: lfh}, nil
 }
+
+func (u *CacheOnReadFs) Symlink(oldname, newname string) error {
+	return u.base.Symlink(oldname, newname)
+}

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -290,3 +290,7 @@ func (u *CopyOnWriteFs) MkdirAll(name string, perm os.FileMode) error {
 func (u *CopyOnWriteFs) Create(name string) (File, error) {
 	return u.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
 }
+
+func (u *CopyOnWriteFs) Symlink(oldname, newname string) error {
+	return ErrNotImplemented // FIXME implement
+}

--- a/memmap.go
+++ b/memmap.go
@@ -363,6 +363,10 @@ func (m *MemMapFs) List() {
 	}
 }
 
+func (m *MemMapFs) Symlink(oldname, newname string) error {
+	return ErrNotImplemented // FIXME implement
+}
+
 // func debugMemMapList(fs Fs) {
 // 	if x, ok := fs.(*MemMapFs); ok {
 // 		x.List()

--- a/os.go
+++ b/os.go
@@ -87,6 +87,10 @@ func (OsFs) Stat(name string) (os.FileInfo, error) {
 	return os.Stat(name)
 }
 
+func (OsFs) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
 func (OsFs) Chmod(name string, mode os.FileMode) error {
 	return os.Chmod(name, mode)
 }

--- a/readonlyfs.go
+++ b/readonlyfs.go
@@ -78,3 +78,7 @@ func (r *ReadOnlyFs) MkdirAll(n string, p os.FileMode) error {
 func (r *ReadOnlyFs) Create(n string) (File, error) {
 	return nil, syscall.EPERM
 }
+
+func (r *ReadOnlyFs) Symlink(oldname, newname string) error {
+	return syscall.EPERM
+}

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -144,6 +144,16 @@ func (r *RegexpFs) Create(name string) (File, error) {
 	return r.source.Create(name)
 }
 
+func (r *RegexpFs) Symlink(oldname, newname string) error {
+	if err := r.matchesName(oldname); err != nil {
+		return err
+	}
+	if err := r.matchesName(newname); err != nil {
+		return err
+	}
+	return r.source.Symlink(oldname, newname)
+}
+
 func (f *RegexpFile) Close() error {
 	return f.f.Close()
 }


### PR DESCRIPTION
This adds symlink support to `OsFs`, `CacheOnReadFs`, `ReadOnlyFs`, and `RegexpFs`. On other filesystems it returns `ErrNotImplemented`.